### PR TITLE
fix: Use replace instead of replaceAll

### DIFF
--- a/src/__tests__/config/tokens.test.ts
+++ b/src/__tests__/config/tokens.test.ts
@@ -23,7 +23,7 @@ const tokensToTest = omitBy(tokens, (token) => (
   symbolsExcludedFromAllTests.has(token.symbol)));
 
 const toComparableSymbol = (s: string) => (
-  s.replaceAll(/[\s-_()$]/g, '')
+  s.replace(/[\s-_()$]/g, '')
   .toLowerCase()
   .replace('rzgnt', ''));
 


### PR DESCRIPTION
Unit test fix in #46 didn't quite go as planned. Turns out `String.prototype.replaceAll` doesn't exist in Node 14.x, the [version used in the testing workflow](https://github.com/Rug-Zombie/rug-zombie-frontend/blob/962d620b971ba2d949c8fa5f91776d29a4795e80/.github/workflows/test.yml#L16). Substituting in `String.prototype.replace` seems to do the trick.

#### Testing
`yarn test`

**NFT tests for `FEZ` and `Captain Dead Mouth` are still failing because their addresses conflict (still assuming this is by mistake).**