### PR TITLE
fix: Use FLOOR rounding for balances, add tests

### DIFF
--- a/src/__tests__/utils/formatBalance.test.ts
+++ b/src/__tests__/utils/formatBalance.test.ts
@@ -1,0 +1,88 @@
+import BigNumber from 'bignumber.js'
+
+import {
+  DEFAULT_DECIMAL_COUNT,
+  getBalanceAmount,
+  getBalanceNumber,
+  getDecimalAmount,
+  getFullDisplayBalance,
+  formatNumber,
+} from 'utils/formatBalance'
+
+describe('getBalance[Amount|Number]', () => {
+  const testGetBalanceAmountAndNumber = (input: BigNumber, expected: BigNumber) => {
+    const balanceAmount = getBalanceAmount(input)
+    const balanceNumber = getBalanceNumber(input)
+
+    expect(balanceAmount).toEqual(expected)
+    expect(balanceNumber).toEqual(expected.toNumber())
+  }
+
+  it('should move decimal place right by default decimal count', () => {
+    testGetBalanceAmountAndNumber(new BigNumber(15e18), new BigNumber(15))
+  })
+  it('should move number with decimal\'s place right by number right by  default decimal count', () => {
+    testGetBalanceAmountAndNumber(new BigNumber(15.123456e18), new BigNumber(15.123456))
+  })
+  it('should move fractional number\'s decimal right by default decimal count', () => {
+    testGetBalanceAmountAndNumber(new BigNumber(15.123456e13), new BigNumber(0.00015123456))
+  })
+})
+
+describe('getDecimalAmount', () => {
+  it('should zero-pad whole number to default decimal count', () => {
+    const inputAmount = new BigNumber(12)
+    const decimalAmount = getDecimalAmount(inputAmount)
+
+    expect(decimalAmount).toEqual(new BigNumber(12e18))
+  })
+  it('should zero-pad number with decimal to default decimal count', () => {
+    const inputAmount = new BigNumber(12.123)
+    const decimalAmount =  getDecimalAmount(inputAmount)
+
+    expect(decimalAmount).toEqual(new BigNumber(12.123e18))
+  })
+  it('should zero-pad fractional number to default decimal count', () => {
+    const inputAmount = new BigNumber(0.0012123)
+    const decimalAmount =  getDecimalAmount(inputAmount)
+
+    expect(decimalAmount).toEqual(new BigNumber(12.123e14))
+  })
+})
+
+describe('getFullDisplayBalance', () => {
+  it('should shift decimal left by default decimal count', () => {
+    const inputAmount = new BigNumber(2.05e18)
+    const displayBalance = getFullDisplayBalance(inputAmount)
+
+    expect(displayBalance).toEqual('2.05')
+  })
+  it('should trim to desired decimal count', () => {
+    const inputAmount = new BigNumber(2.0532132e18)
+    const displayBalance = getFullDisplayBalance(inputAmount, DEFAULT_DECIMAL_COUNT, 3)
+
+    expect(displayBalance).toEqual('2.053')
+  })
+  it('should trim to desired decimal count (floor)', () => {
+    const inputAmount = new BigNumber(2.0532137e18)
+    const displayBalance = getFullDisplayBalance(inputAmount, 18, 6)
+
+    expect(displayBalance).toEqual('2.053213')
+  })
+})
+
+describe('formatNumber', () => {
+  const testFormatNumber = (input, expected) => {
+    const formatted = formatNumber(input)
+    expect(formatted).toEqual(expected)
+  }
+  it('should zero-pad low-precision (default)', () => {
+    testFormatNumber(2, '2.00')
+  })
+  it('should trim high-precision (default)', () => {
+    testFormatNumber(2.123, '2.12')
+  })
+  it('should leave target-precision untouched (default)', () => {
+    testFormatNumber(2.12, '2.12')
+  })
+})

--- a/src/utils/formatBalance.ts
+++ b/src/utils/formatBalance.ts
@@ -1,29 +1,35 @@
 import BigNumber from 'bignumber.js'
 import { BIG_TEN } from './bigNumber'
 
+export const DEFAULT_DECIMAL_COUNT = 18
+
 /**
  * Take a formatted amount, e.g. 15 BNB and convert it to full decimal value, e.g. 15000000000000000
  */
-export const getDecimalAmount = (amount: BigNumber, decimals = 18) => {
+export const getDecimalAmount = (amount: BigNumber, decimals = DEFAULT_DECIMAL_COUNT): BigNumber => {
   return new BigNumber(amount).times(BIG_TEN.pow(decimals))
 }
 
-export const getBalanceAmount = (amount: BigNumber, decimals = 18) => {
+export const getBalanceAmount = (amount: BigNumber, decimals = DEFAULT_DECIMAL_COUNT): BigNumber => {
   return new BigNumber(amount).dividedBy(BIG_TEN.pow(decimals))
 }
 
 /**
  * This function is not really necessary but is used throughout the site.
  */
-export const getBalanceNumber = (balance: BigNumber, decimals = 18) => {
+export const getBalanceNumber = (balance: BigNumber, decimals = DEFAULT_DECIMAL_COUNT): number => {
   return getBalanceAmount(balance, decimals).toNumber()
 }
 
-export const getFullDisplayBalance = (balance: BigNumber, decimals = 18, decimalsToAppear?: number) => {
-  return balance.dividedBy(BIG_TEN.pow(decimals)).toFixed(decimalsToAppear)
+export const getFullDisplayBalance = (
+    balance: BigNumber,
+    decimals = DEFAULT_DECIMAL_COUNT,
+    decimalsToAppear?: number,
+): string => {
+  return getBalanceAmount(balance, decimals).toFixed(decimalsToAppear, BigNumber.ROUND_FLOOR)
 }
 
-export const formatNumber = (number: number, minPrecision = 2, maxPrecision = 2) => {
+export const formatNumber = (number: number, minPrecision = 2, maxPrecision = 2): string => {
   const options = {
     minimumFractionDigits: minPrecision,
     maximumFractionDigits: maxPrecision,


### PR DESCRIPTION
Some users have been running into an issue where they try to stake in tombs, max out the quantity they can stake, and are met with invalid transaction errors. The root cause of this appears to be a rounding issue (balance being rounded up instead of down). After writing some tests to validate the balance formatting logic, I discovered `getFullDisplayBalance` was indeed rounding up instead of down. Adding `BigNumber.ROUND_FLOOR` as the rounding mode for `toFixed` resolves the problem, at least in the rounding logic.

#### Testing
- `yarn test`
- `yarn devstart` & navigating around the site a bit for sanity