### PR TITLE
fix: Add /home to / (landing) redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, lazy, useState } from 'react'
-import { Router, Route, Switch } from 'react-router-dom'
+import { Router, Route, Switch, Redirect } from 'react-router-dom'
 import { ResetCSS } from '@rug-zombie-libs/uikit'
 import BigNumber from 'bignumber.js'
 import useEagerConnect from 'hooks/useEagerConnect'
@@ -7,14 +7,12 @@ import ToastListener from 'components/ToastListener'
 import { routes } from 'routes'
 import TopMenu from 'components/TopMenu'
 import AppContainer from 'components/AppContainer'
-import Menu from 'components/Menu'
 import Loader from 'components/Loader'
 import Tombs from 'views/Tombs'
 import Gravedigger from 'views/Gravedigger/'
 import { useWeb3React } from '@web3-react/core'
 import SpawnWithUs from 'views/SpawnWithUs'
 import Catacombs from 'views/Catacombs'
-import BurnGraves from 'views/BurnGraves'
 import SuspenseWithChunkError from './components/SuspenseWithChunkError'
 import history from './routerHistory'
 import GlobalStyle from './style/Global'
@@ -89,6 +87,7 @@ const App: React.FC = () => {
           </Route>
           <Route exact path={routes.BLACKMARKET}><BlackMarket /></Route>
           <Route exact path={routes.BARRACKS}><Barracks /></Route>
+          <Route exact path={routes.HOME}><Redirect to={routes.LANDING} /></Route>
           <Route exact path={routes.LANDING}>
             <>
               <TopMenu />

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
-export const routes = { 
+export const routes = {
+    HOME: '/home',
     LANDING: '/',
     SPAWNWITHUS:'/spawnwithus',
     GRAVEDIGGER:'/gravedigger',


### PR DESCRIPTION
The `/home` route was removed, but if a user were to navigate to `/home`, they would be met with a blank page. If the user had RZ bookmarked to `/home` (like me), this might give the impression that the site is broken. This change adds a redirect so users entering from `/home` are redirected to the same standard landing page.

Also dropped some unused imports.

#### Testing
Opened `localhost:3000/home`, redirected to `localhost:3000/`.
