### PR TITLE
fix: Remove interface property

### DIFF
--- a/src/components/Home/components/HomeInstabuyCard.tsx
+++ b/src/components/Home/components/HomeInstabuyCard.tsx
@@ -40,7 +40,6 @@ const StyleCursorPointer = styled.div`
 
 interface InstabuyCardProps {
     id: number;
-    refresh: () => void;
     modalObj: {modal: boolean, setModal: any};
 }
 

--- a/src/views/Catacombs/components/DataLab/DataLab.tsx
+++ b/src/views/Catacombs/components/DataLab/DataLab.tsx
@@ -81,19 +81,17 @@ const DataLab: React.FC<DataLabProps> = ({ modalObj }) => {
                 >
                   <SwiperSlide>
                     <div style={{ paddingTop: '15px', paddingBottom: '15px' }}>
-                      <InstabuyCard id={3} refresh={null} modalObj={modalObj} />
+                      <InstabuyCard id={3} modalObj={modalObj} />
                     </div>
                   </SwiperSlide>
                   <SwiperSlide>
                     <div style={{ paddingTop: '15px', paddingBottom: '15px' }}>
-
-                      <InstabuyCard id={4} refresh={null} modalObj={modalObj} />
+                      <InstabuyCard id={4} modalObj={modalObj} />
                     </div>
                   </SwiperSlide>
                   <SwiperSlide>
                     <div style={{ paddingTop: '15px', paddingBottom: '15px' }}>
-
-                      <InstabuyCard id={5} refresh={null} modalObj={modalObj} />
+                      <InstabuyCard id={5} modalObj={modalObj} />
                     </div>
                   </SwiperSlide>
                 </Swiper>

--- a/src/views/Catacombs/components/DataLab/InstabuyCard.tsx
+++ b/src/views/Catacombs/components/DataLab/InstabuyCard.tsx
@@ -46,7 +46,6 @@ const StyleCardHeader = styled.div`
 
 interface InstabuyCardProps {
   id: number;
-  refresh: () => void;
   modalObj: { modal: boolean, setModal: any };
 }
 


### PR DESCRIPTION
The "unexpected arrow function" error was due to an unused interface property on `InstabuyCardProps`. I removed the `refresh` property from the interface so we don't have to have `refresh={null}` as a prop for `InstabuyCard` anymore.
