### PR TITLE
fix: Reduce nft user info fetch batch size to 30

### DIFF
--- a/src/state/nfts/fetchNftsUser.ts
+++ b/src/state/nfts/fetchNftsUser.ts
@@ -23,7 +23,7 @@ const fetchNftsUser = async (account: string, nftsToFetch: Nft[]): Promise<NftId
 
   const contract = getNftOwnership()
   const resultBatches: NftIdAndUserInfo[][] = await Promise.all(
-    chunk(nftsToFetch, 32).map((nftBatch) =>
+    chunk(nftsToFetch, 30).map((nftBatch) =>
       contract.methods
         .massCheckOwnership(
           account,


### PR DESCRIPTION
Users have been reporting trouble viewing assets on the profile page (specifically, NFTs). Traced that back to the good ol' gas error on read:

```
errors.js:28 Uncaught (in promise) Error: Returned error: out of gas
    at Object.ErrorResponse (errors.js:28:1)
    at index.js:303:1
    at XMLHttpRequest.request.onreadystatechange (index.js:98:1)
```

Reducing the NFT user info fetch batch size a bit seems to help. This probably needs more looking at in the future.

#### Testing
`yarn devstart` & loaded profile page. Failed before batch size reduction, rendered after.