### PR TITLE
fix: Use more multicall fetches to reduce web3 calls

### DIFF
--- a/src/state/graves/fetchGraves.ts
+++ b/src/state/graves/fetchGraves.ts
@@ -23,15 +23,20 @@ const fetchGraves = async (gravesToFetch: GraveConfig[]): Promise<Grave[]> => {
   }
 
   const graveInfoSlices = await multicall(drFrankenstein, gravesToFetch.flatMap(getCallsForGrave))
-  const graveInfos = chunk(graveInfoSlices, 3).map(([poolInfo, unlockFee, totalAllocPoint]) => ({
-    poolInfo, unlockFee, totalAllocPoint,
-  }) as { poolInfo: any, unlockFee: number, totalAllocPoint: number })
+  const graveInfos = chunk(graveInfoSlices, 3).map(
+    ([poolInfo, unlockFee, totalAllocPoint]) =>
+      ({
+        poolInfo,
+        unlockFee,
+        totalAllocPoint,
+      } as { poolInfo: any; unlockFee: number; totalAllocPoint: number }),
+  )
 
   const balanceCalls = graveInfos.map(({ poolInfo }) => ({
-        address: poolInfo.lpToken,
-        name: 'balanceOf',
-        params: [drFrankensteinAddress],
-      }))
+    address: poolInfo.lpToken,
+    name: 'balanceOf',
+    params: [drFrankensteinAddress],
+  }))
   const balances: EthersBigNumber[][] = await multicall(bep20Abi, balanceCalls)
 
   return gravesToFetch.map((grave, i) => {

--- a/src/state/graves/fetchGraves.ts
+++ b/src/state/graves/fetchGraves.ts
@@ -1,53 +1,60 @@
 import BigNumber from 'bignumber.js'
+import { BigNumber as EthersBigNumber } from 'ethers'
+import { chunk } from 'lodash'
+
 import drFrankenstein from 'config/abi/drFrankenstein.json'
+import bep20Abi from 'config/abi/erc20.json'
 import multicall from 'utils/multicall'
 import { getDrFrankensteinAddress } from 'utils/addressHelpers'
 import { GraveConfig } from 'config/constants/types'
 import { getId } from '../../utils'
-import { getBep20Contract } from '../../utils/contractHelpers'
+import { Grave } from '../types'
 
-const fetchGraves = async (gravesToFetch: GraveConfig[]) => {
-  const data = await Promise.all(
-    gravesToFetch.map(async (graveConfig) => {
-      const calls = [
-        {
-          address: getDrFrankensteinAddress(),
-          name: 'poolInfo',
-          params: [getId(graveConfig.pid)],
-        },
-        {
-          address: getDrFrankensteinAddress(),
-          name: 'unlockFeeInBnb',
-          params: [getId(graveConfig.pid)],
-        },
-        {
-          address: getDrFrankensteinAddress(),
-          name: 'totalAllocPoint',
-        },
-      ]
+const fetchGraves = async (gravesToFetch: GraveConfig[]): Promise<Grave[]> => {
+  const drFrankensteinAddress = getDrFrankensteinAddress()
+  const getCallsForGrave = ({ pid }) => {
+    const graveId = getId(pid)
 
-      const [info, unlockFee, totalAllocPoint] = await multicall(drFrankenstein, calls)
-      const allocPoint = new BigNumber(info.allocPoint._hex)
-      const weight = allocPoint.div(new BigNumber(totalAllocPoint))
-      const tokenAmount = new BigNumber(
-        await getBep20Contract(info.lpToken).methods.balanceOf(getDrFrankensteinAddress()).call(),
-      )
-      return {
-        ...graveConfig,
-        poolInfo: {
-          unlockFee: new BigNumber(unlockFee),
-          minimumStake: new BigNumber(info.minimumStake._hex),
-          withdrawCooldown: new BigNumber(info.minimumStakingTime._hex),
-          nftMintTime: new BigNumber(info.nftRevivalTime._hex),
-          lpToken: info.lpToken,
-          tokenAmount,
-          allocPoint,
-          weight,
-        },
-      }
-    }),
-  )
-  return data
+    return [
+      { address: drFrankensteinAddress, name: 'poolInfo', params: [graveId] },
+      { address: drFrankensteinAddress, name: 'unlockFeeInBnb', params: [graveId] },
+      { address: drFrankensteinAddress, name: 'totalAllocPoint' },
+    ]
+  }
+
+  const graveInfoSlices = await multicall(drFrankenstein, gravesToFetch.flatMap(getCallsForGrave))
+  const graveInfos = chunk(graveInfoSlices, 3).map(([poolInfo, unlockFee, totalAllocPoint]) => ({
+    poolInfo, unlockFee, totalAllocPoint,
+  }) as { poolInfo: any, unlockFee: number, totalAllocPoint: number })
+
+  const balanceCalls = graveInfos.map(({ poolInfo }) => ({
+        address: poolInfo.lpToken,
+        name: 'balanceOf',
+        params: [drFrankensteinAddress],
+      }))
+  const balances: EthersBigNumber[][] = await multicall(bep20Abi, balanceCalls)
+
+  return gravesToFetch.map((grave, i) => {
+    const { poolInfo, unlockFee, totalAllocPoint } = graveInfos[i]
+    const [tokenAmount] = balances[i]
+
+    const allocPoint = new BigNumber(poolInfo.allocPoint._hex)
+    const weight = allocPoint.div(new BigNumber(totalAllocPoint))
+
+    return {
+      ...grave,
+      poolInfo: {
+        unlockFee: new BigNumber(unlockFee),
+        minimumStake: new BigNumber(poolInfo.minimumStake._hex),
+        withdrawCooldown: new BigNumber(poolInfo.minimumStakingTime._hex),
+        nftMintTime: new BigNumber(poolInfo.nftRevivalTime._hex),
+        lpToken: poolInfo.lpToken,
+        tokenAmount: new BigNumber(tokenAmount._hex),
+        allocPoint,
+        weight,
+      },
+    }
+  })
 }
 
 export default fetchGraves

--- a/src/state/nfts/fetchNfts.ts
+++ b/src/state/nfts/fetchNfts.ts
@@ -6,13 +6,13 @@ import multicall from '../../utils/multicall'
 const fetchNfts = async (nftsToFetch: Nft[]): Promise<Nft[]> => {
   const calls = nftsToFetch.map(({ address }) => ({
     address: getAddress(address),
-    name: 'totalSupply'
+    name: 'totalSupply',
   }))
 
   const totalSupplies = await multicall(erc721Abi, calls)
   return nftsToFetch.map((nft, i) => ({
     ...nft,
-    totalSupply: totalSupplies[i]
+    totalSupply: totalSupplies[i],
   }))
 }
 

--- a/src/state/nfts/fetchNfts.ts
+++ b/src/state/nfts/fetchNfts.ts
@@ -1,15 +1,19 @@
-import { getErc721Contract } from '../../utils/contractHelpers'
+import erc721Abi from '../../config/abi/erc721.json'
 import { getAddress } from '../../utils/addressHelpers'
 import { Nft } from '../types'
+import multicall from '../../utils/multicall'
 
-const fetchNfts = (nftsToFetch: Nft[]): Promise<Nft[]> =>
-  Promise.all(
-    nftsToFetch.map((nft) =>
-      getErc721Contract(getAddress(nft.address))
-        .methods.totalSupply()
-        .call()
-        .then((totalSupply) => ({ ...nft, totalSupply })),
-    ),
-  )
+const fetchNfts = async (nftsToFetch: Nft[]): Promise<Nft[]> => {
+  const calls = nftsToFetch.map(({ address }) => ({
+    address: getAddress(address),
+    name: 'totalSupply'
+  }))
+
+  const totalSupplies = await multicall(erc721Abi, calls)
+  return nftsToFetch.map((nft, i) => ({
+    ...nft,
+    totalSupply: totalSupplies[i]
+  }))
+}
 
 export default fetchNfts

--- a/src/state/nfts/fetchNftsUser.ts
+++ b/src/state/nfts/fetchNftsUser.ts
@@ -1,4 +1,4 @@
-import {chunk, zipWith} from 'lodash'
+import { chunk, zipWith } from 'lodash'
 
 import { getAddress } from '../../utils/addressHelpers'
 import { Nft, NftUserInfo } from '../types'
@@ -22,8 +22,8 @@ const getOwnedIds = async (account: string, nfts: Nft[]): Promise<number[][]> =>
   const nftOwnershipContract = getNftOwnership()
   const addressBatches: string[][] = chunk(nfts.map(({ address }) => getAddress(address), FETCH_BATCH_SIZE))
   const resultBatches: number[][][] = await Promise.all(
-    addressBatches.map(
-      (addresses) => nftOwnershipContract.methods.massCheckOwnership(account, addresses).call()))
+    addressBatches.map((addresses) => nftOwnershipContract.methods.massCheckOwnership(account, addresses).call()),
+  )
 
   return resultBatches.flat()
 }
@@ -34,7 +34,7 @@ const fetchNftsUser = async (account: string, nftsToFetch: Nft[]): Promise<NftId
   }
 
   const ownerships: number[][] = await getOwnedIds(account, nftsToFetch)
-  return zipWith(nftsToFetch, ownerships, ({ id }, ownedIds) => ({ id, userInfo: { ownedIds }}))
+  return zipWith(nftsToFetch, ownerships, ({ id }, ownedIds) => ({ id, userInfo: { ownedIds } }))
 }
 
 export default fetchNftsUser

--- a/src/state/nfts/index.ts
+++ b/src/state/nfts/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import nftConfig from 'config/constants/nfts'
-import {createSlice, PayloadAction} from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { Nft, NftState } from '../types'
 import fetchNftsUser, { NftIdAndUserInfo } from './fetchNftsUser'
 import fetchNfts from './fetchNfts'

--- a/src/state/nfts/index.ts
+++ b/src/state/nfts/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import nftConfig from 'config/constants/nfts'
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import {createSlice, PayloadAction} from '@reduxjs/toolkit'
 import { Nft, NftState } from '../types'
 import fetchNftsUser, { NftIdAndUserInfo } from './fetchNftsUser'
 import fetchNfts from './fetchNfts'

--- a/src/state/spawningPools/fetchSpawningPools.ts
+++ b/src/state/spawningPools/fetchSpawningPools.ts
@@ -52,16 +52,15 @@ const getStats = async (spawningPoolAddresses: string[]): Promise<Stats[]> => {
   )
 
   const results: number[] = await multicall(spawningPool, calls)
-  return chunk(
-    results,
-    5,
-  ).map(([rewardPerBlock, unlockFeeInBnb, minimumStake, minimumStakingTime, nftIntervalTime]) => ({
-    rewardPerBlock,
-    unlockFee: unlockFeeInBnb,
-    minimumStake,
-    minimumStakingTime,
-    nftMintTime: nftIntervalTime,
-  }))
+  return chunk(results, 5).map(
+    ([rewardPerBlock, unlockFeeInBnb, minimumStake, minimumStakingTime, nftIntervalTime]) => ({
+      rewardPerBlock,
+      unlockFee: unlockFeeInBnb,
+      minimumStake,
+      minimumStakingTime,
+      nftMintTime: nftIntervalTime,
+    }),
+  )
 }
 
 const getLpAddresses = async (spawningPoolConfigs: SpawningPoolConfig[]): Promise<string[]> => {

--- a/src/state/spawningPools/fetchSpawningPools.ts
+++ b/src/state/spawningPools/fetchSpawningPools.ts
@@ -1,107 +1,139 @@
 import BigNumber from 'bignumber.js'
+import { BigNumber as EthersBigNumber } from 'ethers'
+
+import { chunk } from 'lodash'
+import bep20Abi from 'config/abi/erc20.json'
 import spawningPool from 'config/abi/spawningPool.json'
 import pancakePair from 'config/abi/pancakePairAbi.json'
+import pancakeFactoryAbi from 'config/abi/pancakeFactoryAbi.json'
 import multicall from 'utils/multicall'
-import { getAddress } from 'utils/addressHelpers'
+import {
+  getAddress,
+  getApeswapFactoryAddress,
+  getPancakeFactoryAddress,
+  getWbnbAddress,
+  getZombieAddress
+} from 'utils/addressHelpers'
 import { Dex, SpawningPoolConfig } from 'config/constants/types'
-import { getApeswapFactoryContract, getPancakeFactoryContract, getZombieContract } from '../../utils/contractHelpers'
 import { equalAddresses } from '../../utils'
 import { getBalanceAmount } from '../../utils/formatBalance'
 
-const fetchSpawningPools = async (spawningPoolToFetch: SpawningPoolConfig[]) => {
-  const wbnb = {
-    56: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
-    97: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
+interface Stats {
+  rewardPerBlock: number
+  unlockFee: number
+  minimumStake: number
+  minimumStakingTime: number
+  nftMintTime: number
+}
+
+interface LpInfo {
+  reserves: EthersBigNumber[]
+  token0: string
+}
+
+const getRouterAddress = (dex: Dex): string => {
+  switch (dex) {
+    case Dex.PCS_V2:
+      return getPancakeFactoryAddress()
+    case Dex.APESWAP:
+      return getApeswapFactoryAddress()
+    default:
+      return getPancakeFactoryAddress()
   }
-  const data = await Promise.all(
-    spawningPoolToFetch.map(async (spawningPoolConfig) => {
-      let calls = [
-        {
-          address: getAddress(spawningPoolConfig.address),
-          name: 'rewardPerBlock',
-          params: [],
-        },
-        {
-          address: getAddress(spawningPoolConfig.address),
-          name: 'unlockFeeInBnb',
-          params: [],
-        },
-        {
-          address: getAddress(spawningPoolConfig.address),
-          name: 'minimumStake',
-          params: [],
-        },
-        {
-          address: getAddress(spawningPoolConfig.address),
-          name: 'minimumStakingTime',
-          params: [],
-        },
-        {
-          address: getAddress(spawningPoolConfig.address),
-          name: 'nftRevivalTime',
-          params: [],
-        },
-      ]
+}
 
-      const [rewardPerBlock, unlockFee, minimumStake, minimumStakingTime, nftMintTime] = await multicall(
-        spawningPool,
-        calls,
-      )
+const getStats = async (spawningPoolAddresses: string[]): Promise<Stats[]> => {
+  const calls = spawningPoolAddresses.flatMap((address) => [
+      'rewardPerBlock', 'unlockFeeInBnb', 'minimumStake', 'minimumStakingTime', 'nftRevivalTime',
+  ].map((method) => ({
+    address,
+    name: method,
+    params: [],
+  })))
 
-      let router
-      switch (spawningPoolConfig.dex) {
-        case Dex.PCS_V2:
-          router = getPancakeFactoryContract()
-          break
-        case Dex.APESWAP:
-          router = getApeswapFactoryContract()
-          break
-        default:
-          router = getPancakeFactoryContract()
-          break
-      }
+  const results: number[] = await multicall(spawningPool, calls)
+  return chunk(
+      results,
+      5,
+    ).map(([
+      rewardPerBlock,
+      unlockFeeInBnb,
+      minimumStake,
+      minimumStakingTime,
+      nftIntervalTime,
+  ]) => ({ rewardPerBlock, unlockFee: unlockFeeInBnb, minimumStake, minimumStakingTime, nftMintTime: nftIntervalTime }))
+}
 
-      const lpAddress = await router.methods
-        .getPair(getAddress(wbnb), getAddress(spawningPoolConfig.rewardToken.address))
-        .call()
+const getLpAddresses = async (spawningPoolConfigs: SpawningPoolConfig[]): Promise<string[]> => {
+  const wbnbAddress = getWbnbAddress()
+  const calls = spawningPoolConfigs.map(({ dex, rewardToken }) => ({
+    address: getRouterAddress(dex),
+    name: 'getPair',
+    params: [wbnbAddress, getAddress(rewardToken.address)],
+  }))
 
-      calls = [
-        {
-          address: lpAddress,
-          name: 'getReserves',
-          params: [],
-        },
-        {
-          address: lpAddress,
-          name: 'token0',
-          params: [],
-        },
-      ]
+  const rawLpAddresses = await multicall(pancakeFactoryAbi, calls)
+  return rawLpAddresses.map(([address]) => address)
+}
 
-      const totalAmount = await getZombieContract().methods.balanceOf(getAddress(spawningPoolConfig.address)).call()
+const getLpInfo = async (lpAddresses: string[]): Promise<LpInfo[]> => {
+  const lpReserveCalls = lpAddresses.flatMap((address) => [
+    { address, name: 'getReserves' },
+    { address, name: 'token0' },
+  ])
 
-      const [reserves, [token0]] = await multicall(pancakePair, calls)
+  const rawResults: [[EthersBigNumber, EthersBigNumber] | [string]][] = await multicall(pancakePair, lpReserveCalls)
+  const chunks: [[EthersBigNumber, EthersBigNumber], [string]][] = chunk(rawResults, 2) as any[]
 
-      const bnbReserve = reserves[equalAddresses(token0, getAddress(wbnb)) ? 0 : 1]
-      const rewardTokenReserve = reserves[equalAddresses(token0, getAddress(wbnb)) ? 1 : 0]
-      const rewardTokenPriceBnb = getBalanceAmount(new BigNumber(bnbReserve._hex)).div(
-        getBalanceAmount(rewardTokenReserve._hex, spawningPoolConfig.rewardToken.decimals),
-      )
-      return {
-        ...spawningPoolConfig,
-        poolInfo: {
-          rewardPerBlock: new BigNumber(rewardPerBlock),
-          unlockFee: new BigNumber(unlockFee),
-          minimumStake: new BigNumber(minimumStake),
-          withdrawCooldown: new BigNumber(minimumStakingTime),
-          nftMintTime: new BigNumber(nftMintTime),
-          totalAmount: new BigNumber(totalAmount),
-          rewardTokenPriceBnb,
-        },
-      }
-    }),
-  )
-  return data
+  return chunks.map(([reserves, [token0]]) => ({ reserves, token0 }))
+}
+
+const getTotalAmounts = (spawningPoolAddresses: string[]): Promise<number[]> => {
+  const zombieAddress = getZombieAddress()
+  const calls = spawningPoolAddresses.map((address) => ({
+    address: zombieAddress,
+    name: 'balanceOf',
+    params: [address],
+  }))
+
+  return multicall(bep20Abi, calls)
+}
+
+const fetchSpawningPools = async (spawningPoolsToFetch: SpawningPoolConfig[]) => {
+  const spawningPoolAddresses = spawningPoolsToFetch.map(({ address }) => getAddress(address))
+
+  const [stats, lpAddresses, totalAmounts] = await Promise.all([
+    getStats(spawningPoolAddresses),
+    getLpAddresses(spawningPoolsToFetch),
+    getTotalAmounts(spawningPoolAddresses),
+  ])
+
+  const lpReserves = await getLpInfo(lpAddresses)
+
+  return spawningPoolsToFetch.map((spawningPoolConfig, i) => {
+    const { rewardPerBlock, unlockFee, minimumStake, minimumStakingTime, nftMintTime } = stats[i]
+    const totalAmount = totalAmounts[i]
+    const { reserves, token0 } = lpReserves[i]
+
+    const wbnbAddress = getWbnbAddress()
+    const bnbReserve = reserves[equalAddresses(token0, wbnbAddress) ? 0 : 1]
+    const rewardTokenReserve = reserves[equalAddresses(token0, wbnbAddress) ? 1 : 0]
+    const rewardTokenPriceBnb = getBalanceAmount(new BigNumber(bnbReserve._hex)).div(
+      getBalanceAmount(new BigNumber(rewardTokenReserve._hex), spawningPoolConfig.rewardToken.decimals),
+    )
+    return {
+      ...spawningPoolConfig,
+      poolInfo: {
+        rewardPerBlock: new BigNumber(rewardPerBlock),
+        unlockFee: new BigNumber(unlockFee),
+        minimumStake: new BigNumber(minimumStake),
+        withdrawCooldown: new BigNumber(minimumStakingTime),
+        nftMintTime: new BigNumber(nftMintTime),
+        totalAmount: new BigNumber(totalAmount),
+        rewardTokenPriceBnb,
+      },
+    }
+  })
 }
 
 export default fetchSpawningPools

--- a/src/state/spawningPools/fetchSpawningPools.ts
+++ b/src/state/spawningPools/fetchSpawningPools.ts
@@ -12,7 +12,7 @@ import {
   getApeswapFactoryAddress,
   getPancakeFactoryAddress,
   getWbnbAddress,
-  getZombieAddress
+  getZombieAddress,
 } from 'utils/addressHelpers'
 import { Dex, SpawningPoolConfig } from 'config/constants/types'
 import { equalAddresses } from '../../utils'
@@ -43,25 +43,25 @@ const getRouterAddress = (dex: Dex): string => {
 }
 
 const getStats = async (spawningPoolAddresses: string[]): Promise<Stats[]> => {
-  const calls = spawningPoolAddresses.flatMap((address) => [
-      'rewardPerBlock', 'unlockFeeInBnb', 'minimumStake', 'minimumStakingTime', 'nftRevivalTime',
-  ].map((method) => ({
-    address,
-    name: method,
-    params: [],
-  })))
+  const calls = spawningPoolAddresses.flatMap((address) =>
+    ['rewardPerBlock', 'unlockFeeInBnb', 'minimumStake', 'minimumStakingTime', 'nftRevivalTime'].map((method) => ({
+      address,
+      name: method,
+      params: [],
+    })),
+  )
 
   const results: number[] = await multicall(spawningPool, calls)
   return chunk(
-      results,
-      5,
-    ).map(([
-      rewardPerBlock,
-      unlockFeeInBnb,
-      minimumStake,
-      minimumStakingTime,
-      nftIntervalTime,
-  ]) => ({ rewardPerBlock, unlockFee: unlockFeeInBnb, minimumStake, minimumStakingTime, nftMintTime: nftIntervalTime }))
+    results,
+    5,
+  ).map(([rewardPerBlock, unlockFeeInBnb, minimumStake, minimumStakingTime, nftIntervalTime]) => ({
+    rewardPerBlock,
+    unlockFee: unlockFeeInBnb,
+    minimumStake,
+    minimumStakingTime,
+    nftMintTime: nftIntervalTime,
+  }))
 }
 
 const getLpAddresses = async (spawningPoolConfigs: SpawningPoolConfig[]): Promise<string[]> => {

--- a/src/state/tombs/fetchTombOverlayUser.ts
+++ b/src/state/tombs/fetchTombOverlayUser.ts
@@ -1,30 +1,10 @@
-import BigNumber from 'bignumber.js'
 import tombOverlay from 'config/abi/tombOverlay.json'
-import drFrankenstein from 'config/abi/drFrankenstein.json'
 import multicall from 'utils/multicall'
-import { getDrFrankensteinAddress, getTombOverlayAddress } from 'utils/addressHelpers'
+import { getTombOverlayAddress } from 'utils/addressHelpers'
 import { TombConfig } from 'config/constants/types'
 import { getId } from '../../utils'
 
-export const fetchTombUserEarnings = async (account: string, tombsToFetch: TombConfig[]) => {
-  const drFrankensteinAddress = getDrFrankensteinAddress()
-
-  const calls = tombsToFetch.map((grave) => {
-    return {
-      address: drFrankensteinAddress,
-      name: 'pendingZombie',
-      params: [getId(grave.pid), account],
-    }
-  })
-
-  const rawEarnings = await multicall(drFrankenstein, calls)
-  const parsedEarnings = rawEarnings.map((earnings) => {
-    return new BigNumber(earnings).toJSON()
-  })
-  return parsedEarnings
-}
-
-export const fetchTombOverlayUserInfo = async (account: string, tombOverlaysToFetch: TombConfig[]) => {
+const fetchTombOverlayUserInfo = async (account: string, tombOverlaysToFetch: TombConfig[]) => {
   const calls = tombOverlaysToFetch.reduce((userInfos, tombConfig) => {
     const overlayId = getId(tombConfig.overlay.pid).toString()
     return userInfos.concat([
@@ -54,3 +34,5 @@ export const fetchTombOverlayUserInfo = async (account: string, tombOverlaysToFe
   }
   return pairedUserInfos
 }
+
+export default fetchTombOverlayUserInfo

--- a/src/state/tombs/fetchTombOverlays.ts
+++ b/src/state/tombs/fetchTombOverlays.ts
@@ -1,39 +1,35 @@
 import BigNumber from 'bignumber.js'
+import { BigNumber as EthersBigNumber } from 'ethers'
+import { chunk, zipWith } from 'lodash'
+
 import tombOverlay from 'config/abi/tombOverlay.json'
 import multicall from 'utils/multicall'
 import { getTombOverlayAddress } from 'utils/addressHelpers'
 import { TombConfig } from 'config/constants/types'
 import { getId } from '../../utils'
 
+interface TombPoolInfo {
+    isEnabled: boolean
+    mintingTime: EthersBigNumber
+}
+
 const fetchTombOverlays = async (tombsToFetch: TombConfig[]) => {
-  const data = await Promise.all(
-    tombsToFetch.map(async (tombConfig) => {
-      const calls = [
-        {
-          address: getTombOverlayAddress(),
-          name: 'poolInfo',
-          params: [getId(tombConfig.overlay.pid)],
-        },
-        {
-          address: getTombOverlayAddress(),
-          name: 'mintingFeeInBnb',
-          params: [],
-        },
-      ]
+    const tombOverlayAddress = getTombOverlayAddress()
+    const calls = tombsToFetch.flatMap((tomb) => [
+        { address: tombOverlayAddress, name: 'poolInfo', params: [getId(tomb.overlay.pid)] },
+        { address: tombOverlayAddress, name: 'mintingFeeInBnb', params: [] }
+    ])
 
-      const [info, fee] = await multicall(tombOverlay, calls)
+    const responses = await multicall(tombOverlay, calls)
 
-      return {
-        ...tombConfig,
+    return zipWith(tombsToFetch, chunk(responses, 2) as [TombPoolInfo, EthersBigNumber][], (tomb, [info, fee]) => ({
+        ...tomb,
         poolInfo: {
-          mintingIsEnabled: info.isEnabled,
-          nftMintTime: new BigNumber(info.mintingTime._hex),
-          mintingFee: new BigNumber(fee),
-        },
-      }
-    }),
-  )
-  return data
+            mintingIsEnabled: info.isEnabled,
+            nftMintTime: new BigNumber(info.mintingTime._hex),
+            mintingFee: new BigNumber(fee._hex),
+        }
+    }))
 }
 
 export default fetchTombOverlays

--- a/src/state/tombs/fetchTombOverlays.ts
+++ b/src/state/tombs/fetchTombOverlays.ts
@@ -9,27 +9,27 @@ import { TombConfig } from 'config/constants/types'
 import { getId } from '../../utils'
 
 interface TombPoolInfo {
-    isEnabled: boolean
-    mintingTime: EthersBigNumber
+  isEnabled: boolean
+  mintingTime: EthersBigNumber
 }
 
 const fetchTombOverlays = async (tombsToFetch: TombConfig[]) => {
-    const tombOverlayAddress = getTombOverlayAddress()
-    const calls = tombsToFetch.flatMap((tomb) => [
-        { address: tombOverlayAddress, name: 'poolInfo', params: [getId(tomb.overlay.pid)] },
-        { address: tombOverlayAddress, name: 'mintingFeeInBnb', params: [] }
-    ])
+  const tombOverlayAddress = getTombOverlayAddress()
+  const calls = tombsToFetch.flatMap((tomb) => [
+    { address: tombOverlayAddress, name: 'poolInfo', params: [getId(tomb.overlay.pid)] },
+    { address: tombOverlayAddress, name: 'mintingFeeInBnb', params: [] },
+  ])
 
-    const responses = await multicall(tombOverlay, calls)
+  const responses = await multicall(tombOverlay, calls)
 
-    return zipWith(tombsToFetch, chunk(responses, 2) as [TombPoolInfo, EthersBigNumber][], (tomb, [info, fee]) => ({
-        ...tomb,
-        poolInfo: {
-            mintingIsEnabled: info.isEnabled,
-            nftMintTime: new BigNumber(info.mintingTime._hex),
-            mintingFee: new BigNumber(fee._hex),
-        }
-    }))
+  return zipWith(tombsToFetch, chunk(responses, 2) as [TombPoolInfo, EthersBigNumber][], (tomb, [info, fee]) => ({
+    ...tomb,
+    poolInfo: {
+      mintingIsEnabled: info.isEnabled,
+      nftMintTime: new BigNumber(info.mintingTime._hex),
+      mintingFee: new BigNumber(fee._hex),
+    },
+  }))
 }
 
 export default fetchTombOverlays

--- a/src/state/tombs/fetchTombOverlays.ts
+++ b/src/state/tombs/fetchTombOverlays.ts
@@ -22,12 +22,12 @@ const fetchTombOverlays = async (tombsToFetch: TombConfig[]) => {
 
   const responses = await multicall(tombOverlay, calls)
 
-  return zipWith(tombsToFetch, chunk(responses, 2) as [TombPoolInfo, EthersBigNumber][], (tomb, [info, fee]) => ({
+  return zipWith(tombsToFetch, chunk(responses, 2) as [TombPoolInfo, number][], (tomb, [info, fee]) => ({
     ...tomb,
     poolInfo: {
       mintingIsEnabled: info.isEnabled,
       nftMintTime: new BigNumber(info.mintingTime._hex),
-      mintingFee: new BigNumber(fee._hex),
+      mintingFee: new BigNumber(fee),
     },
   }))
 }

--- a/src/state/tombs/fetchTombs.ts
+++ b/src/state/tombs/fetchTombs.ts
@@ -1,78 +1,124 @@
 import BigNumber from 'bignumber.js'
+import { BigNumber as EthersBigNumber } from 'ethers'
+import { chunk, zipWith } from 'lodash'
+
 import drFrankenstein from 'config/abi/drFrankenstein.json'
 import lpPair from 'config/abi/pancakePairAbi.json'
+import bep20Abi from 'config/abi/erc20.json'
 import multicall from 'utils/multicall'
-import { getAddress, getDrFrankensteinAddress } from 'utils/addressHelpers'
+import {getAddress, getDrFrankensteinAddress, getWbnbAddress} from 'utils/addressHelpers'
 import { TombConfig } from 'config/constants/types'
 import { getId } from '../../utils'
-import { getBep20Contract } from '../../utils/contractHelpers'
+
+interface LpInfo {
+  reserves: [EthersBigNumber, EthersBigNumber]
+  totalSupply: number
+  token0: string
+  tokenAmount: number
+}
+
+const getLpInfo = async (tombConfigs: TombConfig[]): Promise<LpInfo[]> => {
+  const drFrankensteinAddress = getDrFrankensteinAddress()
+  const addresses = tombConfigs.map(({ lpAddress }) => getAddress(lpAddress))
+
+  const infoCalls = addresses.flatMap((address) => [
+    {
+      address,
+      name: 'getReserves',
+      params: [],
+    },
+    {
+      address,
+      name: 'totalSupply',
+      params: [],
+    },
+    {
+      address,
+      name: 'token0',
+    },
+  ])
+  const amountCalls = addresses.map((address) => ({
+    address,
+    name: 'balanceOf',
+    params: [drFrankensteinAddress],
+  }))
+
+  const [infoResults, amountResults]: [any[], number[]] = await Promise.all([
+    multicall(lpPair, infoCalls),
+    multicall(bep20Abi, amountCalls),
+  ])
+
+  return zipWith(
+    chunk(infoResults, 3) as [[EthersBigNumber, EthersBigNumber], number, string][],
+    amountResults as number[],
+    ([ reserves, totalSupply, token0 ], tokenAmount) => ({
+      reserves, totalSupply, token0, tokenAmount,
+    }))
+}
+
+const getTombInfo = async (
+  tombConfigs: TombConfig[],
+): Promise<{
+  info: {
+    allocPoint: EthersBigNumber,
+    lpToken: string,
+    minimumStakingTime: EthersBigNumber,
+  },
+  totalAllocPoint: number,
+}[]> => {
+  const address = getDrFrankensteinAddress()
+  const calls = tombConfigs.flatMap(({ pid }) => [
+    {
+      address,
+      name: 'poolInfo',
+      params: [getId(pid)],
+    },
+    {
+      address,
+      name: 'totalAllocPoint',
+    }
+  ])
+
+  const results = await multicall(drFrankenstein, calls)
+  return (chunk(results, 2) as [any, number][]).map(([info, totalAllocPoint]) => ({
+    info,
+    totalAllocPoint,
+  }))
+}
 
 const fetchTombs = async (tombsToFetch: TombConfig[]) => {
-  const wbnb = {
-    56: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
-    97: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
-  }
+  const wbnbAddress = getWbnbAddress()
 
-  const data = await Promise.all(
-    tombsToFetch.map(async (tombConfig) => {
-      let calls = [
-        {
-          address: getAddress(tombConfig.lpAddress),
-          name: 'getReserves',
-          params: [],
-        },
-        {
-          address: getAddress(tombConfig.lpAddress),
-          name: 'totalSupply',
-          params: [],
-        },
-        {
-          address: getAddress(tombConfig.lpAddress),
-          name: 'token0',
-        },
-      ]
+  const [lpInfos, tombInfos] = await Promise.all([
+    getLpInfo(tombsToFetch),
+    getTombInfo(tombsToFetch),
+  ])
 
-      const [reserves, totalSupply, token0] = await multicall(lpPair, calls)
+  return zipWith(tombsToFetch, lpInfos, tombInfos, (tombConfig, lpInfo, tombInfo) => {
+    const { reserves, totalSupply, token0, tokenAmount } = lpInfo
+    const { info, totalAllocPoint } = tombInfo
 
-      calls = [
-        {
-          address: getDrFrankensteinAddress(),
-          name: 'poolInfo',
-          params: [getId(tombConfig.pid)],
-        },
-        {
-          address: getDrFrankensteinAddress(),
-          name: 'totalAllocPoint',
-        },
-      ]
+    const bnbReserve = reserves[token0 === wbnbAddress ? 0 : 1]
+    const tokenReserve = reserves[token0 === getWbnbAddress() ? 1 : 0]
+    const tokenPriceBnb = new BigNumber(bnbReserve._hex).div(tokenReserve._hex)
+    const lpPriceBnb = tokenPriceBnb.times(tokenReserve._hex).plus(bnbReserve._hex).div(totalSupply)
 
-      const [info, totalAllocPoint] = await multicall(drFrankenstein, calls)
+    const allocPoint = new BigNumber(info.allocPoint._hex)
+    const weight = allocPoint.div(new BigNumber(totalAllocPoint))
 
-      const bnbReserve = reserves[token0 === getAddress(wbnb) ? 0 : 1]
-      const tokenReserve = reserves[token0 === getAddress(wbnb) ? 1 : 0]
-      const tokenPriceBnb = new BigNumber(bnbReserve._hex).div(tokenReserve._hex)
-      const lpPriceBnb = tokenPriceBnb.times(tokenReserve._hex).plus(bnbReserve._hex).div(totalSupply)
-
-      const allocPoint = new BigNumber(info.allocPoint._hex)
-      const weight = allocPoint.div(new BigNumber(totalAllocPoint))
-      const tokenAmount = new BigNumber(
-        await getBep20Contract(info.lpToken).methods.balanceOf(getDrFrankensteinAddress()).call(),
-      )
-      return {
-        ...tombConfig,
-        poolInfo: {
-          lpReserves: [new BigNumber(reserves[0]._hex), new BigNumber(reserves[1]._hex)],
-          lpTotalSupply: new BigNumber(totalSupply._hex),
-          withdrawCooldown: new BigNumber(info.minimumStakingTime._hex),
-          lpPriceBnb,
-          tokenAmount,
-          allocPoint,
-          weight,
-        },
-      }
-    }),
-  )
-  return data
+    return {
+      ...tombConfig,
+      poolInfo: {
+        lpReserves: [new BigNumber(reserves[0]._hex), new BigNumber(reserves[1]._hex)],
+        lpTotalSupply: new BigNumber(totalSupply),
+        withdrawCooldown: new BigNumber(info.minimumStakingTime._hex),
+        lpPriceBnb,
+        tokenAmount: new BigNumber(tokenAmount),
+        allocPoint,
+        weight,
+      },
+    }
+  })
 }
 
 export default fetchTombs

--- a/src/state/tombs/fetchTombs.ts
+++ b/src/state/tombs/fetchTombs.ts
@@ -6,7 +6,7 @@ import drFrankenstein from 'config/abi/drFrankenstein.json'
 import lpPair from 'config/abi/pancakePairAbi.json'
 import bep20Abi from 'config/abi/erc20.json'
 import multicall from 'utils/multicall'
-import {getAddress, getDrFrankensteinAddress, getWbnbAddress} from 'utils/addressHelpers'
+import { getAddress, getDrFrankensteinAddress, getWbnbAddress } from 'utils/addressHelpers'
 import { TombConfig } from 'config/constants/types'
 import { getId } from '../../utils'
 
@@ -51,21 +51,27 @@ const getLpInfo = async (tombConfigs: TombConfig[]): Promise<LpInfo[]> => {
   return zipWith(
     chunk(infoResults, 3) as [[EthersBigNumber, EthersBigNumber], number, string][],
     amountResults as number[],
-    ([ reserves, totalSupply, token0 ], tokenAmount) => ({
-      reserves, totalSupply, token0, tokenAmount,
-    }))
+    ([reserves, totalSupply, token0], tokenAmount) => ({
+      reserves,
+      totalSupply,
+      token0,
+      tokenAmount,
+    }),
+  )
 }
 
 const getTombInfo = async (
   tombConfigs: TombConfig[],
-): Promise<{
-  info: {
-    allocPoint: EthersBigNumber,
-    lpToken: string,
-    minimumStakingTime: EthersBigNumber,
-  },
-  totalAllocPoint: number,
-}[]> => {
+): Promise<
+  {
+    info: {
+      allocPoint: EthersBigNumber
+      lpToken: string
+      minimumStakingTime: EthersBigNumber
+    }
+    totalAllocPoint: number
+  }[]
+> => {
   const address = getDrFrankensteinAddress()
   const calls = tombConfigs.flatMap(({ pid }) => [
     {
@@ -76,7 +82,7 @@ const getTombInfo = async (
     {
       address,
       name: 'totalAllocPoint',
-    }
+    },
   ])
 
   const results = await multicall(drFrankenstein, calls)
@@ -89,10 +95,7 @@ const getTombInfo = async (
 const fetchTombs = async (tombsToFetch: TombConfig[]) => {
   const wbnbAddress = getWbnbAddress()
 
-  const [lpInfos, tombInfos] = await Promise.all([
-    getLpInfo(tombsToFetch),
-    getTombInfo(tombsToFetch),
-  ])
+  const [lpInfos, tombInfos] = await Promise.all([getLpInfo(tombsToFetch), getTombInfo(tombsToFetch)])
 
   return zipWith(tombsToFetch, lpInfos, tombInfos, (tombConfig, lpInfo, tombInfo) => {
     const { reserves, totalSupply, token0, tokenAmount } = lpInfo

--- a/src/state/tombs/index.ts
+++ b/src/state/tombs/index.ts
@@ -7,7 +7,7 @@ import { fetchTombUserEarnings, fetchTombUserInfo, fetchTombUserTokenInfo } from
 import { Tomb, TombsState } from '../types'
 import { BIG_ZERO } from '../../utils/bigNumber'
 import { getId } from '../../utils'
-import { fetchTombOverlayUserInfo } from './fetchTombOverlayUser'
+import fetchTombOverlayUserInfo from './fetchTombOverlayUser'
 import fetchTombOverlays from './fetchTombOverlays'
 
 const noAccountTombConfig: Tomb[] = tombsConfig.map((tomb) => ({


### PR DESCRIPTION
Modifies/rewrites fetching logic in the new Redux store to minimize the amount of contract calls made.

Even the amount of multicall invocations decreases. For example, some crude A/B numbers:
|Page|Before (multicalls/refresh)|After (multicalls/refresh)|
|-|-|-|
|Home|93|11|
|Graves|91|8|
|Tombs|22|13|
|Spawning Pools|83|12|
|Profile|59|19|

Noticeable improvements to load times. For #74 though, I believe we'll need to optimize the user activity fetching logic. I already have some work in progress for that, but thought I'd keep that out of this PR.

### Testing
Navigated around site & paid close attention to js console + redux tools.