### PR TITLE
User Activity Fetching Optimizations

### DIFF
--- a/src/__tests__/utils/asyncHelpers.test.ts
+++ b/src/__tests__/utils/asyncHelpers.test.ts
@@ -1,0 +1,56 @@
+import { invokeAfter, retry } from 'utils/asyncHelpers'
+
+afterAll(() => jest.useRealTimers())
+
+jest.useFakeTimers()
+jest.spyOn(global, 'setTimeout')
+
+describe('invokeAfter', () => {
+  it('invokes call immediately when delay 0', () => {
+    expect(invokeAfter(() => 2, 0)).resolves.toBe(2)
+    expect(setTimeout).not.toHaveBeenCalled()
+  })
+  it('delays invocation when delay positive', () => {
+    expect(invokeAfter(() => Promise.resolve(2), 100)).resolves.toBe(2)
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 100)
+  })
+})
+
+describe('retry', () => {
+  it('returns immediately if first attempt successful', () => {
+    expect(retry(jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(2).mockReturnValueOnce(3))).resolves.toBe(1)
+  })
+  it('returns second result if first attempt failed', () => {
+    expect(retry(jest.fn().mockRejectedValueOnce(1).mockReturnValueOnce(2).mockReturnValueOnce(3))).resolves.toBe(2)
+  })
+  it('returns third result if first two attempts fail', () => {
+    expect(retry(jest.fn().mockRejectedValueOnce(1).mockRejectedValueOnce(2).mockReturnValueOnce(3))).resolves.toBe(3)
+  })
+  it('throws exception if all attempts fail', () => {
+    expect(retry(jest.fn().mockRejectedValueOnce(1).mockRejectedValueOnce(2).mockRejectedValueOnce(3))).rejects.toBe(3)
+  })
+  it('returns result of first successful call with custom retries', () => {
+    expect(
+      retry(
+        jest
+          .fn()
+          .mockRejectedValueOnce(1)
+          .mockRejectedValueOnce(2)
+          .mockRejectedValueOnce(3)
+          .mockRejectedValueOnce(4)
+          .mockReturnValueOnce(5)
+          .mockReturnValueOnce(6),
+        6,
+      ),
+    ).resolves.toBe(5)
+  })
+  it('pauses [delay] millis between retry attempts', () => {
+    expect(retry(jest.fn().mockRejectedValueOnce(1).mockRejectedValueOnce(2).mockReturnValueOnce(3), 3, 100))
+      .resolves.toBe(3)
+      .then(() => {
+        expect(setTimeout).toHaveBeenCalledTimes(2)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 100)
+      })
+  })
+})

--- a/src/state/userActivites/index.ts
+++ b/src/state/userActivites/index.ts
@@ -10,6 +10,7 @@ export const userActivitySlice = createSlice({
   initialState,
   reducers: {
     setUserActivity: (state, action) => {
+      state.userDataLoaded = true
       state.data = action.payload
     },
   },

--- a/src/state/userActivites/index.ts
+++ b/src/state/userActivites/index.ts
@@ -1,18 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit'
-import { flatten } from 'lodash'
-import { fetchDrFEvents } from './fetchUserActivities'
+import fetchDrFEvents from './fetchUserActivities'
 import { UserActivityState } from '../types'
-import web3 from '../../utils/web3'
-import { range } from '../../utils'
-
-function timeout(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-async function sleep(delay, fn, ...args) {
-  await timeout(delay)
-  return fn(...args)
-}
 
 const initialState: UserActivityState = { data: [], userDataLoaded: false }
 
@@ -31,18 +20,7 @@ export const { setUserActivity } = userActivitySlice.actions
 
 // Thunks
 export const fetchUserActivityAsync = (account: string) => async (dispatch) => {
-  const CHUNKS = 5
-  const MAX_BLOCK_QUERY_SIZE = 5000
-  const DELAY = 1500
-  const currentBlock = await web3.eth.getBlockNumber()
-
-  const drFEventChunks = await Promise.all(
-    range(0, CHUNKS - 1).map((i) => {
-      return sleep(i * DELAY, fetchDrFEvents, account, currentBlock - MAX_BLOCK_QUERY_SIZE * i)
-    }),
-  )
-
-  const drFEvents = flatten(drFEventChunks)
+  const drFEvents = await fetchDrFEvents(account)
 
   const arrayOfUserEventObjects = drFEvents.sort((a, b) =>
     // eslint-disable-next-line no-nested-ternary

--- a/src/utils/asyncHelpers.ts
+++ b/src/utils/asyncHelpers.ts
@@ -1,0 +1,41 @@
+/**
+ * Invoke an operation after a specified delay.
+ *
+ * @param fn Callable to invoke
+ * @param delay Delay in milliseconds
+ * @return Value returned by call
+ */
+export const invokeAfter = <T>(fn: () => T | Promise<T>, delay: number): Promise<T> =>
+  delay > 0
+    ? new Promise((resolve) => setTimeout(() => Promise.resolve(fn()).then((result) => resolve(result)), delay))
+    : Promise.resolve(fn())
+
+/**
+ * Attempt to invoke an operation, retrying up to a specified number of times upon failure.
+ *
+ * @param fn Callable to invoke
+ * @param maxAttempts Maximum number of attempts permitted. Default 3
+ * @param delay Delay between attempts in milliseconds. Default 0
+ * @return Value returned by callable, if successful
+ */
+export const retry = async <T>(fn: () => T | Promise<T>, maxAttempts = 3, delay?: number): Promise<T> => {
+  let lastError
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      let result
+      if (attempt > 1 && delay) {
+        // eslint-disable-next-line no-await-in-loop
+        result = await invokeAfter(fn, delay)
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        result = await fn()
+      }
+
+      return result
+    } catch (e) {
+      lastError = e
+    }
+  }
+
+  throw lastError
+}

--- a/src/views/Profile/ProfilePage/components/ActivityCard.tsx
+++ b/src/views/Profile/ProfilePage/components/ActivityCard.tsx
@@ -64,7 +64,17 @@ const ActivityText = styled.p`
   letter-spacing: 0px;
   color: #ffffff;
   flex-shrink: 2;
-  width: 65%; ;
+  width: 65%;;
+`
+
+const Loading = styled.p`
+  text-align: left;
+  font: normal normal 300 14px/40px Poppins;
+  letter-spacing: 0px;
+  color: #ffffff;
+  flex-shrink: 2;
+  width: 65%;;
+  padding-left: 50px;
 `
 
 const ProfilePage: React.FC = () => {
@@ -72,7 +82,9 @@ const ProfilePage: React.FC = () => {
 
   const getNftByAddress = (address: string) => nfts.find((n) => equalAddresses(getAddress(n.address), address))
 
-  const activities = useGetUserActivities().data
+  const activityState = useGetUserActivities()
+  const activities = activityState.data
+  const loaded = activityState.userDataLoaded
 
   const activityText = ({ type, data }: UserActivity) => {
     const amount = new BigNumber(data.amount)
@@ -102,14 +114,16 @@ const ProfilePage: React.FC = () => {
         if (tombPids().includes(pid)) {
           return (
             <ActivityText>
-              Unstaked {numeral(getBalanceNumber(amountWithdrawn)).format('(0.00 a)')} LP from {getDrFPoolName(pid)}{' '}
+              Unstaked {numeral(getBalanceNumber(amountWithdrawn)).format('(0.00 a)')} LP
+              from {getDrFPoolName(pid)}{' '}
               tomb
             </ActivityText>
           )
         }
         return (
           <ActivityText>
-            Withdrew {numeral(getBalanceNumber(amountWithdrawn)).format('(0.00 a)')} ZMBE from {getDrFPoolName(pid)}{' '}
+            Withdrew {numeral(getBalanceNumber(amountWithdrawn)).format('(0.00 a)')} ZMBE
+            from {getDrFPoolName(pid)}{' '}
             grave
           </ActivityText>
         )
@@ -139,19 +153,21 @@ const ProfilePage: React.FC = () => {
   return (
     <Card>
       <CardTitle>Activity</CardTitle>
-      <InnerCardDiv className="scroll">
+      <InnerCardDiv className='scroll'>
         <ActivitiesFlex>
-          {activities.map((activity) => {
-            // if (activity.type === UserActivityType.DrFHarvest) {
-            //   return null
-            // }
-            return (
-              <ActivityDiv>
-                <DateText>{formatDuration(now() - activity.timestamp, false, true)} ago</DateText>
-                <ActivityText>{activityText(activity)}</ActivityText>
-              </ActivityDiv>
-            )
-          })}
+          {/* eslint-disable-next-line no-nested-ternary */}
+          {loaded ? activities.length > 0 ? activities.map((activity) => {
+              // if (activity.type === UserActivityType.DrFHarvest) {
+              //   return null
+              // }
+              return (
+                <ActivityDiv>
+                  <DateText>{formatDuration(now() - activity.timestamp, false, true)} ago</DateText>
+                  <ActivityText>{activityText(activity)}</ActivityText>
+                </ActivityDiv>
+              )
+            }) : <Loading>No recent activity...</Loading>
+            : <Loading>Loading your activity...</Loading>}
         </ActivitiesFlex>
       </InnerCardDiv>
     </Card>

--- a/src/views/Profile/ProfilePage/components/ActivityCard.tsx
+++ b/src/views/Profile/ProfilePage/components/ActivityCard.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
-import { useWeb3React } from '@web3-react/core'
 import { BigNumber } from 'bignumber.js'
 import numeral from 'numeral'
-import { fetchUserActivityAsync } from '../../../../state/userActivites'
-import { useAppDispatch } from '../../../../state'
 import { useGetNfts, useGetUserActivities } from '../../../../state/hooks'
 import { UserActivity } from '../../../../state/types'
 import { UserActivityType } from '../../../../config/constants/types'
@@ -71,15 +68,7 @@ const ActivityText = styled.p`
 `
 
 const ProfilePage: React.FC = () => {
-  const { account } = useWeb3React()
-  const dispatch = useAppDispatch()
   const nfts = useGetNfts().data
-
-  useEffect(() => {
-    if (account) {
-      dispatch(fetchUserActivityAsync(account))
-    }
-  }, [account, dispatch])
 
   const getNftByAddress = (address: string) => nfts.find((n) => equalAddresses(getAddress(n.address), address))
 

--- a/src/views/Profile/ProfilePage/components/StakingInfoCard.tsx
+++ b/src/views/Profile/ProfilePage/components/StakingInfoCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { useWeb3React } from '@web3-react/core'
-import { fetchUserActivityAsync } from '../../../../state/userActivites'
 import { useAppDispatch } from '../../../../state'
 import { useGetGraves, useGetSpawningPools, useGetTombs } from '../../../../state/hooks'
 import '../../Profile.Styles.css'
@@ -89,11 +88,6 @@ const ProfilePage: React.FC = () => {
   const { account } = useWeb3React()
   const web3 = useWeb3()
   const dispatch = useAppDispatch()
-  useEffect(() => {
-    if (account) {
-      dispatch(fetchUserActivityAsync(account))
-    }
-  }, [account, dispatch])
 
   useEffect(() => {
     if (account) {

--- a/src/views/Profile/ProfilePage/index.tsx
+++ b/src/views/Profile/ProfilePage/index.tsx
@@ -14,6 +14,7 @@ import ActivityCard from './components/ActivityCard'
 import StakingInfoCard from './components/StakingInfoCard'
 import NftCard from '../../Graveyard/components/Nfts/components/NftCard'
 import Page from '../../../components/layout/Page'
+import { fetchUserActivityAsync } from '../../../state/userActivites'
 
 const BannerImage = styled.img`
   min-width: 317px;
@@ -98,6 +99,11 @@ const ProfilePage: React.FC = () => {
 
   useEffect(() => {
     dispatch(fetchNftUserDataAsync(account))
+  }, [dispatch, account])
+  useEffect(() => {
+    if (account) {
+      dispatch(fetchUserActivityAsync(account))
+    }
   }, [dispatch, account])
 
   return (


### PR DESCRIPTION
- Reduces `getPastEvents` batches to single calls that pull all events, from which relevant events are then filtered.
- Adds retries to `getPastEvents`. These still seem to fail intermittently, but it's less frequent now.
  - New `invokeAfter` and `retry` helpers added to new `util/asyncHelpers`
  - Due to improved flexibility through retries, I was able to shorten the delay between calls from `1500 ms` to `100 ms`. Still takes a good amount of time though.
- Individual user activity fetches moved from `StakingInfoCard` and `ActivityCard` to the main `Profile` pages so it's only fetched once (was happening twice before).

Should resolve #74; not seeing gas errors anymore.

#### Testing
- `yarn test`
- `yarn lint`
- `yarn format:check`
- Countless refreshes :)