### PR TITLE
fix: Activity grave name null error

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,7 +51,9 @@ export function getDrFPoolName(pid: number): string {
   if (tombPids().includes(pid)) {
     return `${DEXS[tombs.find((t) => getId(t.pid) === pid).dex]}`
   }
-  return `${graves.find((g) => getId(g.pid) === pid).name}`
+
+  const grave = graves.find((g) => getId(g.pid) === pid)
+  return grave && grave.name
 }
 
 export function tombPids(): number[] {


### PR DESCRIPTION
Encountered this error while loading the Profile page in dev mode:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'name')
    at getDrFPoolName (index.ts:54:1)
    at activityText (ActivityCard.tsx:104:1)
    at ActivityCard.tsx:166:1
    at Array.map (<anonymous>)
    at ProfilePage (ActivityCard.tsx:157:1)
    at renderWithHooks (react-dom.development.js:14985:1)
```

It seems one of the activities, or at least an intermediate state of the render of one, corresponded to a grave not present in the constants. Adjusting `getDrFPoolName` to handle a missing grave result seemed to do the trick.