### PR TITLE
feat: Restore telegram & twitter links

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -54,8 +54,8 @@ const Footer: React.FC = () => {
           })}
         </FooterLists>
         <FooterIcons>
-          <FooterIcon src={telegram} alt="Telegram Icon" />
-          <FooterIcon src={twitter} alt="Twitter Icon" />
+          <FooterIcon src={telegram} alt="Telegram Icon" onClick={() => window.open('https://t.me/rugzombie')} />
+          <FooterIcon src={twitter} alt="Twitter Icon" onClick={() => window.open('https://twitter.com/rugzombie')} />
         </FooterIcons>
       </FooterContent>
     </FooterContainer>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -15,6 +15,7 @@ import {
   FooterList,
   FooterListItem,
   FooterIcons,
+  FooterIconLink,
   FooterIcon,
 } from './styles'
 
@@ -54,8 +55,12 @@ const Footer: React.FC = () => {
           })}
         </FooterLists>
         <FooterIcons>
-          <FooterIcon src={telegram} alt="Telegram Icon" onClick={() => window.open('https://t.me/rugzombie')} />
-          <FooterIcon src={twitter} alt="Twitter Icon" onClick={() => window.open('https://twitter.com/rugzombie')} />
+          <FooterIconLink href="https://t.me/rugzombie" target="_blank" rel="noopener noreferrer">
+            <FooterIcon src={telegram} alt="Telegram Icon" />
+          </FooterIconLink>
+          <FooterIconLink href="https://twitter.com/rugzombie" target="_blank" rel="noopener noreferrer">
+            <FooterIcon src={twitter} alt="Twitter Icon" />
+          </FooterIconLink>
         </FooterIcons>
       </FooterContent>
     </FooterContainer>

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -70,13 +70,16 @@ export const FooterIcons = styled.div`
   justify-content: flex-start;
 `
 
-export const FooterIcon = styled.img`
+export const FooterIconLink = styled.a`
   width: 40px;
   height: 40px;
   margin: 5px;
   border-radius: 25px;
+`
+
+export const FooterIcon = styled.img`
+  width: 40px;
+  height: 40px;
+  border-radius: 25px;
   border: 1px solid #b8c00d;
-  :hover {
-    cursor: pointer;
-  }
 `

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -71,7 +71,12 @@ export const FooterIcons = styled.div`
 `
 
 export const FooterIcon = styled.img`
-  width: 50px;
-  height: 50px;
-  padding: 10px;
+  width: 40px;
+  height: 40px;
+  margin: 5px;
+  border-radius: 25px;
+  border: 1px solid #b8c00d;
+  :hover {
+    cursor: pointer;
+  }
 `


### PR DESCRIPTION
Restores footer hyperlinks to the Telegram and Twitter. Also changes styling a bit.

Before:
<img width="1261" alt="Screen Shot 2022-03-06 at 20 55 21" src="https://user-images.githubusercontent.com/84021981/156965351-72a07d42-31dc-4234-86fe-667c265f0035.png">


After:
<img width="1259" alt="Screen Shot 2022-03-06 at 20 55 12" src="https://user-images.githubusercontent.com/84021981/156965304-2833c142-2ca7-4354-b967-9c0d36788075.png">
