### PR TITLE
feat: Nft-only grave card styling

### DIFF
--- a/src/views/Graves/components/GraveTable/components/Bottom/components/ConvertNftModal/index.tsx
+++ b/src/views/Graves/components/GraveTable/components/Bottom/components/ConvertNftModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Button, Flex, Modal, Text } from '@rug-zombie-libs/uikit'
+import { Flex, Modal, Text } from '@rug-zombie-libs/uikit'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
 import { useERC721, useNftConverter } from '../../../../../../../../hooks/useContract'
@@ -108,7 +108,6 @@ const ConvertNftModal: React.FC<ConvertNftModalProps> = ({ depositNftId, nftConv
   }, [onDismiss, onNftConvert])
 
   const handleApprove = () => {
-    console.log(!approved)
     if (account && !approved) {
       setApproving(true)
       nftContract.methods

--- a/src/views/Graves/components/GraveTable/components/Top/index.tsx
+++ b/src/views/Graves/components/GraveTable/components/Top/index.tsx
@@ -59,22 +59,8 @@ const TabFlex = styled.div`
   }
 `
 
-const GreenTab = styled.div`
-  width: 49px;
-  height: 30px;
-  border: 2px solid #b8c00d;
-  border-radius: 15px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0 5px;
-  @media (max-width: 527px) {
-    margin: 0;
-  }
-`
-
 const GreyTab = styled.div`
-  width: 60px;
+  padding: 0 10px;
   height: 30px;
   border: 2px solid #6b7682;
   border-radius: 15px;
@@ -86,14 +72,31 @@ const GreyTab = styled.div`
   }
 `
 
-const GreenTabText = styled.div`
-  font: normal normal normal 12px/30px Poppins;
-  color: #ffffff;
+const GreenTab = styled(GreyTab)`
+  border: 2px solid #b8c00d;
+  margin: 0 5px;
+  @media (max-width: 527px) {
+    margin: 0;
+  }
+`
+
+const BlueTab = styled(GreyTab)`
+  border: 2px solid #4b7bdc;
+  margin-left: 5px;
+`
+
+const PinkTab = styled(GreyTab)`
+  border: 2px solid #ae32aa;
+  margin-left: 5px;
 `
 
 const GreyTabText = styled.div`
   font: normal normal normal 12px/30px Poppins;
   color: #6b7682;
+`
+
+const WhiteTabText = styled(GreyTabText)`
+  color: #ffffff;
 `
 
 const GraveSubRow = styled.div`
@@ -132,6 +135,7 @@ const Top: React.FC<TopProps> = ({ grave, open, setOpen }) => {
     isNew,
     poolInfo: { allocPoint, tokenAmount, weight },
     userInfo: { pendingZombie, nftMintDate, tokenWithdrawalDate, amount },
+    isRetired,
   } = grave
   const toggleOpen = () => setOpen(!open)
   const tokenImage = (token: Token) => {
@@ -157,6 +161,44 @@ const Top: React.FC<TopProps> = ({ grave, open, setOpen }) => {
     return <CardItem label="Withdrawal Timer" value={remainingCooldownTime} valueType={CardItemValueType.Duration} />
   }
 
+  const isNftOnly: boolean = allocPoint.isZero() && !isRetired
+  const getTabs = () => {
+    const tabs = []
+
+    if (isNftOnly) {
+      tabs.push(
+        <BlueTab>
+          <WhiteTabText>NFT-ONLY</WhiteTabText>
+        </BlueTab>,
+      )
+    } else if (isRetired) {
+      tabs.push(
+        <PinkTab>
+          <WhiteTabText>RETIRED</WhiteTabText>
+        </PinkTab>,
+      )
+    } else {
+      tabs.push(
+        <GreenTab>
+          <WhiteTabText>{allocPoint.div(100).toString()}X</WhiteTabText>
+        </GreenTab>,
+        <GreyTab>
+          <GreyTabText>ZMBE</GreyTabText>
+        </GreyTab>,
+      )
+    }
+
+    if (isNew) {
+      tabs.push(
+        <GreenTab>
+          <WhiteTabText>NEW</WhiteTabText>
+        </GreenTab>,
+      )
+    }
+
+    return <TabFlex>{tabs}</TabFlex>
+  }
+
   return (
     <GraveColumn onClick={toggleOpen}>
       <GraveHeaderRow>
@@ -165,31 +207,23 @@ const Top: React.FC<TopProps> = ({ grave, open, setOpen }) => {
           <img src={tokenImage(rug)} style={{ width: '30px', height: '30px' }} alt="Rug token logo" />
         </TokenFlex>
         <GraveTitle>{name}</GraveTitle>
-        <TabFlex>
-          <GreenTab>
-            <GreenTabText>{allocPoint.div(100).toString()}X</GreenTabText>
-          </GreenTab>
-          <GreyTab>
-            <GreyTabText>ZMBE</GreyTabText>
-          </GreyTab>
-          {isNew ? (
-            <GreenTab>
-              <GreenTabText>NEW</GreenTabText>
-            </GreenTab>
-          ) : null}
-        </TabFlex>
+        {getTabs()}
       </GraveHeaderRow>
       <GraveSubRow>
         <Amounts>
-          <CardItem
-            label="Earned"
-            unit="ZMBE"
-            value={getBalanceNumber(pendingZombie)}
-            highlightable
-            valueType={CardItemValueType.Number}
-          />
-          <CardItem label="Yearly" value={yearly} valueType={CardItemValueType.Percentage} />
-          <CardItem label="Daily" value={daily} valueType={CardItemValueType.Percentage} />
+          {!isNftOnly && (
+            <>
+              <CardItem
+                label="Earned"
+                unit="ZMBE"
+                value={getBalanceNumber(pendingZombie)}
+                highlightable
+                valueType={CardItemValueType.Number}
+              />
+              <CardItem label="Yearly" value={yearly} valueType={CardItemValueType.Percentage} />
+              <CardItem label="Daily" value={daily} valueType={CardItemValueType.Percentage} />
+            </>
+          )}
           <CardItem label="TVL" value={tvl} valueType={CardItemValueType.Money} />
         </Amounts>
         <Percentages>


### PR DESCRIPTION
Changes styling of NFT-only grave cards, providing a blue `NFT-ONLY` label for clarity. Similarly, adds a `RETIRED` label for retired graves. Adjusts styling slightly for all labels on graves; see below for examples.

#### NFT-Only Grave

Before:
![old-nft-only-grave](https://user-images.githubusercontent.com/84021981/157719693-1434e344-6be2-488f-af16-b2c4971e1e83.png)

After:
![new-nft-only-grave](https://user-images.githubusercontent.com/84021981/157719716-f9733084-7912-4d29-8195-88313480d885.png)

#### Retired Grave

Before:
![old-retired-grave](https://user-images.githubusercontent.com/84021981/157719758-6e133038-76bb-4990-9c61-9b160979dfc8.png)

After:
![new-retired-grave](https://user-images.githubusercontent.com/84021981/157719780-bda563ca-3831-410e-9626-3720ffc51ef1.png)


#### Regular Grave

Before:
![old-normal-grave](https://user-images.githubusercontent.com/84021981/157719569-4215915b-9a1b-44d6-b675-08e5fbc0a815.png)

After:
![new-normal-grave](https://user-images.githubusercontent.com/84021981/157719599-ba0d7f98-1bf8-4a62-8d63-6fca6c064d90.png)

