### PR TITLE
feat: Connect wallet message for graves, tombs, spawning pools

### DIFF
--- a/src/views/Graves/index.tsx
+++ b/src/views/Graves/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { Flex } from "@rug-zombie-libs/uikit";
 import React, { useEffect, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
@@ -97,6 +98,8 @@ const Graves: React.FC = () => {
   const handleFilter = (condition: string) => setFilter(condition)
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)
 
+  const isUserDependentFilter: boolean = filter === 'Staked'
+
   return (
     <>
       <GravePage>
@@ -106,9 +109,14 @@ const Graves: React.FC = () => {
           </Header>
           <GravesColumn>
             <Filter searchValue={search} handleFilter={handleFilter} handleSearch={handleSearch} />
-            {orderedGraves.map((g) => {
-              return <GraveTable grave={g} key={getId(g.pid)} />
-            })}
+            {(isUserDependentFilter && !account) ?
+              <Flex style={{ paddingTop: '10px', width: '100%', justifyContent: 'center' }}>
+                <div className="total-earned text-shadow">Connect Wallet to view staked graves</div>
+              </Flex>
+              : orderedGraves.map((g) => {
+                return <GraveTable grave={g} key={getId(g.pid)} />
+              })
+            }
           </GravesColumn>
         </Row>
       </GravePage>

--- a/src/views/SpawningPools/index.tsx
+++ b/src/views/SpawningPools/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { Flex } from "@rug-zombie-libs/uikit";
 import React, { useEffect, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
@@ -70,6 +71,8 @@ const SpawningPools: React.FC = () => {
   const handleFilter = (condition: string) => setFilter(condition)
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)
 
+  const isUserDependentFilter = filter === 'Staked'
+
   return (
     <>
       <SpawningPoolPage>
@@ -79,9 +82,12 @@ const SpawningPools: React.FC = () => {
           </Header>
           <SpawningPoolsColumn>
             <Filter searchValue={search} handleFilter={handleFilter} handleSearch={handleSearch} />
-            {spawningPools.map((sp) => {
-              return <SpawningPoolTable spawningPool={sp} key={sp.id} />
-            })}
+            {(isUserDependentFilter && !account) ? (
+              <Flex style={{ paddingTop: '10px', width: '100%', justifyContent: 'center' }}>
+                <div className="total-earned text-shadow">Connect Wallet to view staked spawning pools</div>
+              </Flex>
+            ) : spawningPools.map((sp) => <SpawningPoolTable spawningPool={sp} key={sp.id} />)
+            }
           </SpawningPoolsColumn>
         </Row>
       </SpawningPoolPage>

--- a/src/views/Tombs/index.tsx
+++ b/src/views/Tombs/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { Flex } from "@rug-zombie-libs/uikit";
 import React, { useEffect, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
@@ -84,6 +85,8 @@ const Tombs: React.FC = () => {
     })
   }
 
+  const isUserDependentFilter = tombFilter === TombFilter.Staked
+
   return (
     <>
       <TombPage>
@@ -99,9 +102,12 @@ const Tombs: React.FC = () => {
               rarityFilter={{ value: rarityFilter, set: setRarityFilter }}
               setSearch={setSearchFilter}
             />
-            {tombs.map((g) => {
-              return <TombTable tomb={g} key={getId(g.pid)} />
-            })}
+            {(isUserDependentFilter && !account) ? (
+              <Flex style={{ paddingTop: '10px', width: '100%', justifyContent: 'center' }}>
+                <div className="total-earned text-shadow">Connect Wallet to view staked tombs</div>
+              </Flex>
+              ) : tombs.map((g) => <TombTable tomb={g} key={getId(g.pid)} />)
+            }
           </TombsColumn>
         </Row>
       </TombPage>


### PR DESCRIPTION
Displays a `Connect Wallet to view staked [graves|tombs|spawning pools]` message if the user selects the `Staked` filter before they are logged in.

##### Graves
![graves](https://user-images.githubusercontent.com/84021981/157722343-ba46e34e-a803-42d2-b55d-3f180824087d.png)

##### Tombs
![tombs](https://user-images.githubusercontent.com/84021981/157722414-82342a6f-e826-41dc-8dcd-fdedf6f8bb9b.png)

##### Spawning Pools
![spawning-pools](https://user-images.githubusercontent.com/84021981/157722389-2ec5db90-a571-4571-b6d1-60f9d7f57d30.png)
