### PR TITLE
Contract links

### DIFF
--- a/src/components/ContractLink.tsx
+++ b/src/components/ContractLink.tsx
@@ -1,0 +1,24 @@
+import { LinkExternal } from '@rug-zombie-libs/uikit'
+import React from 'react'
+import styled from 'styled-components'
+import { getBscScanLink } from 'utils'
+
+const LinkContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+`
+
+interface Props {
+  address: string
+  linkText?: string
+}
+
+const ContractLink: React.FC<Props> = ({ address, linkText }) => {
+  return (
+    <LinkContainer>
+      <LinkExternal href={getBscScanLink(address, 'address')}>{linkText || 'Contract'}</LinkExternal>
+    </LinkContainer>
+  )
+}
+
+export default ContractLink

--- a/src/views/Graves/components/HeaderCard/index.tsx
+++ b/src/views/Graves/components/HeaderCard/index.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable no-param-reassign */
+import ContractLink from 'components/ContractLink'
 import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
+import { getDrFrankensteinAddress } from 'utils/addressHelpers'
 import { BIG_ZERO } from '../../../../utils/bigNumber'
 import { getBalanceNumber } from '../../../../utils/formatBalance'
 import { useGetGraveByPid, useGetGraves, useGetZombiePriceUsd } from '../../../../state/hooks'
@@ -111,6 +113,7 @@ const HeaderCard: React.FC = () => {
           <InfoCardTitle>Graves</InfoCardTitle>
           <InfoCardSubHeader>
             Use your dead tokens to unlock graves then stake ZMBE to earn Zombie & NFT rewards.
+            <ContractLink address={getDrFrankensteinAddress()} />
           </InfoCardSubHeader>
         </InfoCardHeader>
         <InfoCardContent>

--- a/src/views/SpawningPools/components/SpawningPoolTable/components/Bottom/components/TableDetails/index.tsx
+++ b/src/views/SpawningPools/components/SpawningPoolTable/components/Bottom/components/TableDetails/index.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
 import { useHistory } from 'react-router'
+import { getAddress } from 'utils/addressHelpers'
+import ContractLink from 'components/ContractLink'
 import { getBalanceAmount, getFullDisplayBalance } from '../../../../../../../../utils/formatBalance'
 import { SpawningPool } from '../../../../../../../../state/types'
 import { formatDays, formatDuration, now } from '../../../../../../../../utils/timerHelpers'
@@ -94,6 +96,7 @@ const Text = styled.span`
 
 const TableDetails: React.FC<TableDetailsProps> = ({ spawningPool }) => {
   const {
+    address,
     nftId,
     endDate,
     poolInfo: { withdrawCooldown, nftMintTime, totalAmount, minimumStake, unlockFee },
@@ -124,6 +127,9 @@ const TableDetails: React.FC<TableDetailsProps> = ({ spawningPool }) => {
           <HeaderText>{name}</HeaderText>
           <SubHeaderText>
             Pool TVL: <Text>{numeral(tvl.toString()).format('$ (0.00 a)')}</Text>
+          </SubHeaderText>
+          <SubHeaderText>
+            <ContractLink address={getAddress(address)} linkText="Pool Contract" />
           </SubHeaderText>
         </SpawningPoolInfo>
         <SpawningPoolInfo>

--- a/src/views/Tombs/components/HeaderCard/index.tsx
+++ b/src/views/Tombs/components/HeaderCard/index.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable no-param-reassign */
+import ContractLink from 'components/ContractLink'
 import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
+import { getDrFrankensteinAddress } from 'utils/addressHelpers'
 import { useGetBnbPriceUsd, useGetTombs } from '../../../../state/hooks'
 import { getBalanceNumber } from '../../../../utils/formatBalance'
 import { BIG_ZERO } from '../../../../utils/bigNumber'
@@ -107,6 +109,7 @@ const HeaderCard: React.FC = () => {
           <InfoCardSubHeader>
             Provide liquidity to roll for various NFTs. Increase your stake in the tombs to increase your chance at
             rolling rare NFTs.
+            <ContractLink address={getDrFrankensteinAddress()} />
           </InfoCardSubHeader>
         </InfoCardHeader>
         <InfoCardContent>

--- a/src/views/Tombs/components/TombTable/components/Bottom/components/TableDetails/index.tsx
+++ b/src/views/Tombs/components/TombTable/components/Bottom/components/TableDetails/index.tsx
@@ -1,6 +1,8 @@
+import ContractLink from 'components/ContractLink'
 import React from 'react'
 import styled from 'styled-components'
 import numeral from 'numeral'
+import { getAddress } from 'utils/addressHelpers'
 import { getFullDisplayBalance } from '../../../../../../../../utils/formatBalance'
 import { Tomb } from '../../../../../../../../state/types'
 import { formatDays } from '../../../../../../../../utils/timerHelpers'
@@ -89,6 +91,7 @@ const Text = styled.span`
 
 const TableDetails: React.FC<TableDetailsProps> = ({ tomb }) => {
   const {
+    lpAddress,
     poolInfo: { allocPoint, withdrawCooldown, nftMintTime, tokenAmount, lpPriceBnb, mintingFee },
     overlay: { legendaryId },
   } = tomb
@@ -123,6 +126,9 @@ const TableDetails: React.FC<TableDetailsProps> = ({ tomb }) => {
           </SubHeaderText>
           <SubHeaderText>
             Tomb TVL: <Text>{numeral(getFullDisplayBalance(tvl)).format('$ (0.00 a)')}</Text>
+          </SubHeaderText>
+          <SubHeaderText>
+            <ContractLink  address={getAddress(lpAddress)} linkText="LP Contract" />
           </SubHeaderText>
         </TombInfo>
         <TombInfo>


### PR DESCRIPTION
Adds contract links for graves, spawning pools, and tombs. All links open in new tab/window.

### Graves

Just adds Dr. Frankenstein contract link in header:

<img width="1315" alt="Screen Shot 2022-04-03 at 18 14 14" src="https://user-images.githubusercontent.com/84021981/161458602-c261e6e0-3c86-4e3c-9eed-aa8d29dd1f38.png">

### Spawning Pools

Link to relevant spawning pool contract added to cards:

<img width="1324" alt="Screen Shot 2022-04-03 at 18 16 04" src="https://user-images.githubusercontent.com/84021981/161458693-e2ef8d2c-5b97-42f0-9366-904358f65c08.png">

### Tombs

Link to Dr. Frankenstein contract in header (left in preview), LP contract links in cards:

<img width="1285" alt="Screen Shot 2022-04-03 at 18 09 58" src="https://user-images.githubusercontent.com/84021981/161458441-872f8c61-6f2b-4a7e-a6c4-8c4709e045fc.png">

