### PR TITLE
refactor: Type-enforce chain id mappings against enum

### DIFF
--- a/src/config/constants/types.ts
+++ b/src/config/constants/types.ts
@@ -1,12 +1,11 @@
-export interface Address {
-  97?: string
-  56: string
+export enum ChainId {
+  BSC = 56,
+  BSCTestnet = 97,
 }
+export type ChainIdMapping<T> = { [key in ChainId]: T }
 
-export interface Id {
-  97?: number
-  56: number
-}
+export type Address = ChainIdMapping<string>
+export type Id = ChainIdMapping<number>
 
 export interface Token {
   symbol: string


### PR DESCRIPTION
Creates `ChainId` enum containing entries for BSC mainnet (`56`) and testnet (`97`) chain ids. Adjusts type definitions for `Id` and `Address` to enforce entries in these structures include all chain ids in the new enum and only those chain ids.

Should help catch bugs ahead of time for future additions, especially upon supporting additional chains.