### PR TITLE
fix: Increase price precision on ZMBE in header

### DIFF
--- a/src/components/TopMenu/index.tsx
+++ b/src/components/TopMenu/index.tsx
@@ -100,11 +100,14 @@ const TopMenu = () => {
           ) : null}
         </DropdownMenu>
         <Buttons>
-          <TokenButton style={{ flexDirection: 'row' }} onClick={() => {
-            window.location.href = 'https://dex.guru/token/0x50ba8bf9e34f0f83f96a340387d1d3888ba4b3b5-bsc'
-          }}>
+          <TokenButton
+            style={{ flexDirection: 'row' }}
+            onClick={() => {
+              window.location.href = 'https://dex.guru/token/0x50ba8bf9e34f0f83f96a340387d1d3888ba4b3b5-bsc'
+            }}
+          >
             <img src={zombiehead} alt="Zombie Icon" style={{ height: '70%', paddingRight: '20px' }} />
-            <Text style={{ fontWeight: 'bold' }}>${useGetZombiePriceUsd().toPrecision(1)}</Text>
+            <Text style={{ fontWeight: 'bold' }}>${useGetZombiePriceUsd().toPrecision(2)}</Text>
           </TokenButton>
           <UnlockButton />
           <ProfileImage onClick={() => history.push(routes.PROFILE)} src={basiczombie} alt="Profile Image" />


### PR DESCRIPTION
I just increased the price precision on the ZMBE price in the header. I've been using it, and wished it showed more detail. .0012 is a lot different than .0018, for example.